### PR TITLE
Fix mistake with Number constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,8 +760,9 @@ myNumber === myNumberObj; // = false
 if (0){
     // This code won't execute, because 0 is falsy.
 }
-if (Number(0)){
-    // This code *will* execute, because Number(0) is truthy.
+if (new Number(0)){
+   // This code will execute, because wrapped numbers are objects, and objects
+   // are always truthy.
 }
 
 // However, the wrapper objects and the regular builtins share a prototype, so


### PR DESCRIPTION
Hi, I prepare for the interview by your repository and found one small mistake related to the constructor of Number. This is really helpful cheatsheet and I hope that you fix this.

```if (Number(0))``` is not truthy because it's also primitive
it returns object only with the "new" operator, like this: ```if (new Number(0))```

Thanks and Good Luck